### PR TITLE
Add notes feature

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -53,6 +53,7 @@ export default function Layout({ children, title, description }) {
           --border: #b6b6c2;
           --button: #4a7ddd;
           --button-text: #fff;
+          --aside: #d7d5ce;
         }
 
         html,

--- a/components/like.tsx
+++ b/components/like.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react"
+import Cookies from 'js-cookie';
+
+const INITIAL_TEXT = "Like?"
+const THANKS_TEXT = "Thanks!"
+const LIKED_TEXT = "Liked ♥︎"
+
+const THANKS_VISIBLE_FOR_MS = 600
+
+export default function Like({ id }: { id: string }) {
+    const alreadyClicked = Cookies.get(id) !== undefined
+
+    // --                                                    --.
+    // Allow a developer (aka me) to clear their local cookies |
+    // of all currently rendered like buttons
+    if (globalThis.debugClearCookiesList === undefined) {
+        globalThis.debugClearCookiesList = []
+        globalThis.debugClearCookies = () => {
+            globalThis.debugClearCookiesList.forEach(f => f())
+        }
+    }
+    globalThis.debugClearCookiesList.push(() => {
+        Cookies.remove(id);
+        console.log('removed', id)
+    })
+    // --                                                    __.
+
+    const [clicked, setClicked] = useState(false)
+    const [liked, setLiked] = useState(alreadyClicked)
+    const [display, setDisplay] = useState(alreadyClicked ? LIKED_TEXT : INITIAL_TEXT)
+
+    useEffect(() => {
+        if (!clicked) {
+            return
+        }
+
+        fetch('/api/like-button', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id })
+        })
+
+        const likedTimer = setTimeout(() => {
+            setDisplay(LIKED_TEXT)
+        }, THANKS_VISIBLE_FOR_MS)
+
+        return () => {
+            clearTimeout(likedTimer)
+        }
+    }, [clicked])
+
+    const click = () => {
+        if (clicked || liked) {
+            return
+        }
+
+        Cookies.set(id, '1')
+        setDisplay(THANKS_TEXT)
+        setClicked(true)
+        setLiked(true)
+    }
+
+    return <>
+        <span id={id} onClick={click} className={`like-btn${!clicked ? ' like-btn-can-click' : ''}`}>{display}</span>
+        <style jsx>{`
+        .like-btn {
+            color: var(--light-text);
+        }
+        .like-btn-can-click:hover {
+            cursor: pointer;
+            color: var(--text);
+        }
+    `}</style>
+    </>
+}

--- a/components/newsletter.tsx
+++ b/components/newsletter.tsx
@@ -9,8 +9,7 @@ export default function Newsletter() {
   return (
     <div className="newsletter-section">
       <p className="newsletter-desc">
-        Subscribe to new posts by email. Something new approximately once per
-        month.
+        Subscribe to new posts (about once a month).
       </p>
       <form
         action={`https://buttondown.email/api/emails/embed-subscribe/${siteConfig.BUTTON_DOWN_USER}`}

--- a/createNote.js
+++ b/createNote.js
@@ -1,0 +1,16 @@
+// Create a note in ./notes/ with the schema ${TIMESTAMP}.md
+// e.g.g  like `./notes/1675415098715.md`
+
+const fs = require('fs')
+const path = require('path')
+const notesDir = './notes'
+
+if (!fs.existsSync(notesDir)) {
+    fs.mkdirSync(notesDir);
+}
+
+const filepath = path.join(notesDir, `${Date.now()}.md`)
+fs.writeFileSync(filepath, '')
+
+// This can be cmd+clicked from VS Code's terminal to open it!
+console.log(filepath)

--- a/lib/notes.ts
+++ b/lib/notes.ts
@@ -1,0 +1,36 @@
+import fs from 'fs'
+import matter from 'gray-matter';
+import path from "path"
+
+const NOTES_DIRECTORY = path.join(process.cwd(), "notes")
+
+export type Note = {
+    id: number,
+    content: string,
+}
+
+export function getAllNotes(): Note[] {
+    const fileNames = fs.readdirSync(NOTES_DIRECTORY)
+    const notes: Note[] = []
+
+    fileNames.forEach((fileName) => {
+        const id = parseInt(fileName.split('.md')[0], 10)
+
+        // Some very light validation
+        // @ts-ignore
+        if (new Date(id) == 'Invalid Date') {
+            throw `${id} isn't a valid date!`
+        }
+
+        const fullPath = path.join(NOTES_DIRECTORY, `${id}.md`);
+        const fileContents = fs.readFileSync(fullPath, "utf8");
+        const matterResult = matter(fileContents)
+        notes.push({
+            id: id,
+            content: matterResult.content
+        })
+    })
+
+    notes.sort((a, z) => z.id - a.id)
+    return notes
+}

--- a/notes/1675415098715.md
+++ b/notes/1675415098715.md
@@ -1,0 +1,3 @@
+Hello, World!
+
+The design of this small notes system is ~~stolen from~~ inspired by https://muan.co/notes.

--- a/notes/1675429937922.md
+++ b/notes/1675429937922.md
@@ -1,0 +1,64 @@
+Playing chess via voice commands.
+
+I'm often pacing around the room while holding my new baby – putting him to sleep, soothing him, burping him. I've also been playing more chess lately.
+
+I hacked together a script to play lichess games via voice commands (so I could put my laptop on top of my wardrobe while holding my almost-asleep baby). The results were okay, I got it to play some moves for me, but it wasn't very reliable (~40% chance I'd need to repeat myself). So I put it aside for now.
+
+Getting a voice recognizer to parse standard notation ("e2e4") seems harder than getting it to parse normal speech (like nouns, verbs, etc). I used [Whisper](https://openai.com/blog/whisper/) via `speech_recognition`, and `pyautogui` to handle clicking.
+
+As you can see below, I tried some manual parsing to help with the accuracy. It would work better if I used more distinct words for the squares rather than standard notation but I wanted to use standard notation.
+
+```python
+import pyautogui
+import speech_recognition
+
+r = speech_recognition.Recognizer()
+
+# lichess.org full screen, 14in MacBook Pro
+top_left = [472, 217]
+bot_right = [991, 738]
+
+# calculate rows
+x_space = (bot_right[0] - top_left[0]) / 7
+x_rows = [top_left[0] + (x_space * i) for i in range(0, 8)]
+y_space = (top_left[1] - bot_right[1]) / 7
+y_rows = [top_left[1] - (y_space * i) for i in range(0, 8)]
+
+
+# e.g "A1" -> (472.0, 217.0)
+def position_to_xy(pos: str):
+    letters = list("HGFEDCBA")
+    numbers = list("12345678")
+
+    letter, number = pos[0], pos[1]
+    xy = (
+        x_rows[letters.index(letter)],
+        y_rows[numbers.index(number)],
+    )
+    return xy
+
+
+while True:
+    with speech_recognition.Microphone() as source:
+        print("waiting..")
+        voice = r.listen(source)
+        command = r.recognize_whisper(voice)
+        print(f"got command: {command}")
+
+        # examples: "E2, E4.", "E2 E4"
+        trimmed = command.upper().strip().replace(".", " ").replace(",", " ")
+        positions = trimmed.split()
+
+        if len(positions) != 2 or len(positions[0]) != 2 or len(positions[1]) != 2:
+            print(f"warn: didn't get a valid position, got: {positions}")
+            continue
+
+        from_square = position_to_xy(positions[0])
+        to_square = position_to_xy(positions[1])
+
+        print(f"moving {positions[0]} -> {positions[1]}")
+        pyautogui.moveTo(from_square[0], from_square[1])
+        pyautogui.click()
+        pyautogui.moveTo(to_square[0], to_square[1])
+        pyautogui.click()
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@playwright/test": "^1.29.2",
+        "@supabase/supabase-js": "^2.7.0",
+        "@types/js-cookie": "^3.0.2",
         "@types/node": "^18.11.18",
         "@types/react": "^18.0.27",
         "@vercel/analytics": "^0.1.8",
@@ -16,6 +18,7 @@
         "feed": "^4.2.2",
         "gray-matter": "^4.0.3",
         "image-size": "^1.0.2",
+        "js-cookie": "^3.0.1",
         "markdown-to-jsx": "^7.1.8",
         "ms": "^2.1.3",
         "next": "^13.1.3",
@@ -241,6 +244,60 @@
         "node": ">=14"
       }
     },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.0.0.tgz",
+      "integrity": "sha512-ozb7bds2yvf5k7NM2ZzUkxvsx4S4i2eRKFSJetdTADV91T65g4gCzEs9L3LUXSrghcGIkUaon03VPzOrFredqg==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@supabase/gotrue-js": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.11.0.tgz",
+      "integrity": "sha512-yo3yExoTqpJH4YpdI5PDjZ1YLOj3wURppimfsV0ep5uxDY/lE1uOhiMCPnhy59DbFAKG7bjnhJ1L7sk+B2os3w==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.3.0.tgz",
+      "integrity": "sha512-XVX0XaWTyT06mtj67gKb0OasP9hUNIYpypgdKnIqBSib5fXD3aRb6U5rt9y9gG1UMi7pCCgv2qulKRIQlHbb9w==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.6.0.tgz",
+      "integrity": "sha512-tOVulMobhpxyDuu8VIImpL8FXmZOKsGNOSyS5ihJdj2xYmPPvYG+D2J51Ewfl+MFF65tweiB6p9N9bNIW1cDNA==",
+      "dependencies": {
+        "@types/phoenix": "^1.5.4",
+        "websocket": "^1.0.34"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.3.0.tgz",
+      "integrity": "sha512-YGWVCEYYYF3+UiyL8O4xC78N9n9paLbT0hHl8dmYAtd3DqyWtu5Eph9JTu0PWm+/29Zhns5TbhUZW4xpWjJfPQ==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.7.0.tgz",
+      "integrity": "sha512-0Ry6rcxeya0VRbPh6fHfgPcmH7X9gMILon7/PWoVJSjYsQntv7EGUNNeHtLutBlm8St74s5Q4sjsqJOPslDG4Q==",
+      "dependencies": {
+        "@supabase/functions-js": "^2.0.0",
+        "@supabase/gotrue-js": "^2.10.2",
+        "@supabase/postgrest-js": "^1.1.1",
+        "@supabase/realtime-js": "^2.4.0",
+        "@supabase/storage-js": "^2.1.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
@@ -249,10 +306,20 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.2.tgz",
+      "integrity": "sha512-6+0ekgfusHftJNYpihfkMu8BWdeHs9EOJuGcSofErjstGPfPGEu9yTu4t460lTzzAMl2cM5zngQJqPMHbbnvYA=="
+    },
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.5.4.tgz",
+      "integrity": "sha512-L5eZmzw89eXBKkiqVBcJfU1QGx9y+wurRIEgt0cuLH0hwNtVUxtx+6cu0R2STwWj468sjXyBYPYDtGclUd1kjQ=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
@@ -290,6 +357,18 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/bufferutil": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001445",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
@@ -310,10 +389,27 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
       "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+    },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
     },
     "node_modules/date-fns": {
       "version": "2.29.3",
@@ -327,6 +423,52 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -338,6 +480,19 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
@@ -400,6 +555,19 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -514,6 +682,40 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/picocolors": {
@@ -670,10 +872,28 @@
         }
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "node_modules/typescript": {
       "version": "4.9.4",
@@ -687,6 +907,48 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "dependencies": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/xml-js": {
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
@@ -696,6 +958,14 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+      "engines": {
+        "node": ">=0.10.32"
       }
     }
   },
@@ -792,6 +1062,60 @@
         "playwright-core": "1.29.2"
       }
     },
+    "@supabase/functions-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.0.0.tgz",
+      "integrity": "sha512-ozb7bds2yvf5k7NM2ZzUkxvsx4S4i2eRKFSJetdTADV91T65g4gCzEs9L3LUXSrghcGIkUaon03VPzOrFredqg==",
+      "requires": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "@supabase/gotrue-js": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.11.0.tgz",
+      "integrity": "sha512-yo3yExoTqpJH4YpdI5PDjZ1YLOj3wURppimfsV0ep5uxDY/lE1uOhiMCPnhy59DbFAKG7bjnhJ1L7sk+B2os3w==",
+      "requires": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "@supabase/postgrest-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.3.0.tgz",
+      "integrity": "sha512-XVX0XaWTyT06mtj67gKb0OasP9hUNIYpypgdKnIqBSib5fXD3aRb6U5rt9y9gG1UMi7pCCgv2qulKRIQlHbb9w==",
+      "requires": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "@supabase/realtime-js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.6.0.tgz",
+      "integrity": "sha512-tOVulMobhpxyDuu8VIImpL8FXmZOKsGNOSyS5ihJdj2xYmPPvYG+D2J51Ewfl+MFF65tweiB6p9N9bNIW1cDNA==",
+      "requires": {
+        "@types/phoenix": "^1.5.4",
+        "websocket": "^1.0.34"
+      }
+    },
+    "@supabase/storage-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.3.0.tgz",
+      "integrity": "sha512-YGWVCEYYYF3+UiyL8O4xC78N9n9paLbT0hHl8dmYAtd3DqyWtu5Eph9JTu0PWm+/29Zhns5TbhUZW4xpWjJfPQ==",
+      "requires": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "@supabase/supabase-js": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.7.0.tgz",
+      "integrity": "sha512-0Ry6rcxeya0VRbPh6fHfgPcmH7X9gMILon7/PWoVJSjYsQntv7EGUNNeHtLutBlm8St74s5Q4sjsqJOPslDG4Q==",
+      "requires": {
+        "@supabase/functions-js": "^2.0.0",
+        "@supabase/gotrue-js": "^2.10.2",
+        "@supabase/postgrest-js": "^1.1.1",
+        "@supabase/realtime-js": "^2.4.0",
+        "@supabase/storage-js": "^2.1.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
     "@swc/helpers": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
@@ -800,10 +1124,20 @@
         "tslib": "^2.4.0"
       }
     },
+    "@types/js-cookie": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.2.tgz",
+      "integrity": "sha512-6+0ekgfusHftJNYpihfkMu8BWdeHs9EOJuGcSofErjstGPfPGEu9yTu4t460lTzzAMl2cM5zngQJqPMHbbnvYA=="
+    },
     "@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+    },
+    "@types/phoenix": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.5.4.tgz",
+      "integrity": "sha512-L5eZmzw89eXBKkiqVBcJfU1QGx9y+wurRIEgt0cuLH0hwNtVUxtx+6cu0R2STwWj468sjXyBYPYDtGclUd1kjQ=="
     },
     "@types/prop-types": {
       "version": "15.7.4",
@@ -839,6 +1173,14 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "bufferutil": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "caniuse-lite": {
       "version": "1.0.30001445",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
@@ -849,20 +1191,96 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "csstype": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
       "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
     },
     "date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
     },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "requires": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "requires": {
+        "type": "^2.7.2"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+        }
+      }
     },
     "extend-shallow": {
       "version": "2.0.1",
@@ -908,6 +1326,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -976,6 +1404,24 @@
         "postcss": "8.4.14",
         "styled-jsx": "5.1.1"
       }
+    },
+    "next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -1078,15 +1524,68 @@
         "client-only": "0.0.1"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+    },
+    "utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "requires": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      }
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "xml-js": {
       "version": "1.6.11",
@@ -1095,6 +1594,11 @@
       "requires": {
         "sax": "^1.2.4"
       }
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@playwright/test": "^1.29.2",
+    "@supabase/supabase-js": "^2.7.0",
+    "@types/js-cookie": "^3.0.2",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",
     "@vercel/analytics": "^0.1.8",
@@ -17,6 +19,7 @@
     "feed": "^4.2.2",
     "gray-matter": "^4.0.3",
     "image-size": "^1.0.2",
+    "js-cookie": "^3.0.1",
     "markdown-to-jsx": "^7.1.8",
     "ms": "^2.1.3",
     "next": "^13.1.3",

--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -1,5 +1,3 @@
-import siteConfig from "../siteConfig.json";
-
 import fs from "fs";
 import path from "path";
 import imageSize from "image-size";
@@ -101,7 +99,6 @@ export default function Post({
         </aside> : null}
         <Markdown
           options={{
-            // Extend plain Markdown posts with React components
             createElement(type, props, children) {
               if (type === "img") {
                 return (
@@ -164,7 +161,7 @@ export default function Post({
           padding-bottom: 32px;
         }
         aside {
-          background-color: #d7d5ce;
+          background-color: var(--aside);
           padding: 1.5em 1.5em;
           margin-bottom: 2.5em;
         }

--- a/pages/api/like-button.ts
+++ b/pages/api/like-button.ts
@@ -1,0 +1,41 @@
+import type { NextRequest } from "next/server"
+import { createClient } from '@supabase/supabase-js'
+
+export const config = {
+    runtime: 'edge',
+    regions: ['iad1'],
+}
+
+type LikePayload = {
+    id: string
+}
+
+// Turn a request into a way to identify-ish users
+// (don't keep personal identifiable information!)
+// e.g. 127.0.0.1 -> `?? | ?? | ?? | MTIC4x`
+const requestToUser = (req: NextRequest) => {
+    const geoStr = `${req.geo.country || '??'} | ${req.geo.region || '??'} | ${req.geo.city || '??'} | `
+    const safeIp = req.ip || '127.0.0.1'
+    const base64ip = btoa(safeIp).toString()
+    const fiveChars = base64ip.slice(0, 3) + base64ip.slice(base64ip.length - 3, base64ip.length)
+    return geoStr + fiveChars
+}
+
+export default async (req: NextRequest) => {
+    const supabaseUrl = process.env.LIKE_DB_URL
+    const supabaseKey = process.env.LIKE_DB_KEY
+    const supabase = createClient(supabaseUrl, supabaseKey)
+
+    const payload: LikePayload = await req.json()
+
+    const { error } = await supabase
+        .from('likes')
+        .insert([
+            { like_id: payload.id, by: requestToUser(req) },
+        ])
+    if (error) {
+        console.log(error, payload, req.ip)
+    }
+
+    return new Response('')
+}

--- a/pages/notes.tsx
+++ b/pages/notes.tsx
@@ -1,0 +1,53 @@
+import Markdown from "markdown-to-jsx";
+import React from "react";
+import Code from "../components/code";
+import Layout from "../components/layout";
+import Like from "../components/like";
+import { getAllNotes, Note } from "../lib/notes";
+
+
+export async function getStaticProps() {
+    const notes = getAllNotes()
+
+    return {
+        props: {
+            notes
+        },
+    };
+}
+
+export default function Notes({ notes }: { notes: Note[] }) {
+    const seo = { title: 'Notes', description: 'Shorter writing.' };
+
+    return (
+        <Layout {...seo}>
+            <h1>Notes</h1>
+            {
+                notes
+                    .map((note) => <div key={note.id} id={note.id.toString()} className="note">
+                        <p>
+                            <a className="note-date-link" href={`#${note.id}`}>{(new Date(note.id)).toDateString()} #</a><Like id={`notes-${note.id}`} />
+                        </p>
+                        <p><Markdown
+                            options={{
+                                createElement(type, props, children) {
+                                    if (type === "code" && props.className) {
+                                        const language = props.className.replace("lang-", "");
+                                        return <Code children={children} language={language} />;
+                                    }
+                                    return React.createElement(type, props, children);
+                                },
+                            }}
+                        >{note.content}</Markdown></p>
+                        <hr />
+                    </div>)
+            }
+            <style jsx>{`
+            .note-date-link {
+                color: var(--light-text);
+                padding-right: 20px;
+            }
+            `}</style>
+        </Layout>
+    )
+}

--- a/pages/notes.tsx
+++ b/pages/notes.tsx
@@ -26,7 +26,7 @@ export default function Notes({ notes }: { notes: Note[] }) {
                 notes
                     .map((note) => <div key={note.id} id={note.id.toString()} className="note">
                         <p>
-                            <a className="note-date-link" href={`#${note.id}`}>{(new Date(note.id)).toDateString()} #</a><Like id={`notes-${note.id}`} />
+                            <a className="note-date-link" href={`#${note.id}`}>{(new Date(note.id)).toDateString()} #</a><Like id={`note-${note.id}`} />
                         </p>
                         <p><Markdown
                             options={{


### PR DESCRIPTION
Add a new page `/notes` that renders the markdown notes from `./notes/` in most-recent first order.

Add a concept of "like buttons" that don't display the total count but let me know if people like something. They're just added on the new, hidden, `/notes` page for now. Like buttons talk to an edge function that inserts into a Supabase DB.

Ship two small notes.